### PR TITLE
Add Deep Analysis Gap Report for M1 v1.1

### DIFF
--- a/artefacts/reports/deep_analysis_gap_m1_v1.1.md
+++ b/artefacts/reports/deep_analysis_gap_m1_v1.1.md
@@ -1,0 +1,28 @@
+# Deep Analysis Gap Report – M1 v1.1
+
+## 1. Übersicht (Ziel M1)
+M1 fokussiert eine selbstheilende Governance-Basis mit Health-Check, robustem Execution-Prompt-Governance-Workflow und Friction-Reduction-Bundle für Operatoren.【F:artefacts/project_plan_v0.4.md†L17-L35】
+Die zugehörigen Arbeiten bündeln die Tickets AT-001, AT-002 sowie den Patch AT-PATCH-01 innerhalb des Execution-/Feedback-Loops.【F:artefacts/systemkarte.md†L21-L37】
+
+## 2. Gap-Tabelle
+| Ticket | Soll-Deliverables | Ist im Repo | Status | Kommentar |
+| --- | --- | --- | --- | --- |
+| AT-001 | Health-Check Script, npm-Task, CI-Ausführung, docs-lite Absicherung, Iteration-Log.【F:tickets/AT-001.md†L13-L20】【F:artefacts/project_plan_v0.4.md†L21-L22】 | Script liefert den erwarteten Output, npm-Script & CI-Step binden ihn ein; docs-lite Workflow vorhanden; Iteration-Log dokumentiert den Rollout.【F:tools/health-check.mjs†L1-L1】【F:package.json†L1-L7】【F:.github/workflows/ci.yml†L1-L14】【F:.github/workflows/docs-lite.yml†L1-L52】【F:artefacts/iteration_log.md†L23-L66】 | OK | Deliverables vollständig, keine Abweichung ersichtlich. |
+| AT-002 | Execution-Prompt-Output, Governance-Workflow (Prettier, UTF-8, Validator, Auto-Format), Loop-Log/Evidence.【F:tickets/AT-002.md†L26-L35】【F:artefacts/project_plan_v0.4.md†L21-L23】 | Meta-Prompt und Governance-Workflow mit Prettier-, UTF-8- und Ticket-Checks existieren; Auto-Format Guardrail aktiv.【F:prompts/meta_prompt@1.0.0.md†L1-L10】【F:.github/workflows/governance.yml†L1-L139】【F:scripts/check-utf8.mjs†L1-L118】【F:scripts/validate-ticket.mjs†L1-L200】【F:.github/workflows/auto-format.yml†L24-L61】 | Drift | `artefacts/execution/` enthält nur `.gitkeep`, Loop-Logs und CI-Metriken fehlen – geforderte Evidence/Outputs wurden nicht abgelegt.【067dd4†L1-L5】【3f4c7c†L1-L2】【09f0f5†L1-L5】 |
+| AT-PATCH-01 | Friction-Bundle (PR-Template, Issue-Form, Editor Defaults, VS Code Tasks, Codex-Trigger, Auto-Format Guardrail).【F:tickets/AT-PATCH-01.md†L9-L26】【F:artefacts/project_plan_v0.4.md†L23-L29】 | Alle Operator-Artefakte und Trigger-Dateien liegen vor; Guardrail begrenzt Auto-Fix-Commits.【F:.github/pull_request_template.md†L1-L30】【F:.github/ISSUE_TEMPLATE/at-ticket.yml†L1-L70】【F:.editorconfig†L1-L11】【F:.vscode/tasks.json†L1-L13】【F:.github/workflows/codex-run.yml†L1-L33】【F:.github/workflows/auto-format.yml†L24-L61】 | Drift | Ticket verlangt Evidence (Codex-Trigger, Screens), doch weder Loop-Logs noch Reports dokumentieren Ausführungen; Codex-Log-Datei fehlt ebenfalls.【F:tickets/AT-PATCH-01.md†L24-L26】【3f4c7c†L1-L2】【09f0f5†L1-L5】 |
+
+## 3. Globale Gaps (max. 5)
+- Keine CI-Kosten-/Laufzeitdaten: `artefacts/reports/ci-metrics.jsonl` fehlt trotz vorhandenem Metrics-Script und Commit-Helper, wodurch KPIs unmessbar bleiben.【09f0f5†L1-L5】【F:scripts/ci-metrics.mjs†L1-L42】【F:scripts/commit-if-changed.mjs†L23-L41】
+- Loop-Logging bleibt ungenutzt: Weder `artefacts/loop_logs/` noch Governance-Logs sind eingecheckt, obwohl Ticket-Validator & Loop-Log-Script bereitstehen.【3f4c7c†L1-L2】【F:tools/loop-log.mjs†L1-L189】【F:.github/workflows/governance.yml†L108-L139】
+- Execution-Evidence fehlt: Keine abgelegten Prompt-Outputs unter `artefacts/execution/`, obwohl Systemkarte & Tickets diese Artefakte erwarten.【067dd4†L1-L5】【F:artefacts/systemkarte.md†L21-L37】【F:tickets/AT-002.md†L26-L35】
+- Codex-Trigger ohne Nachweis: `artefacts/reports/` enthält keinen `codex_triggers.log`, sodass `/codex`-Hybrid-Trigger nicht verifizierbar ist.【09f0f5†L1-L5】【F:.github/workflows/codex-run.yml†L19-L27】
+
+## 4. CI-Kosten (falls Daten vorhanden)
+- Keine Daten – `artefacts/reports/ci-metrics.jsonl` ist nicht vorhanden, daher keine Summen berechenbar.【09f0f5†L1-L5】
+
+## 5. Empfehlung (klar)
+**Entscheidung:** M1: NOT READY  
+**Nächste Schritte (max. 3, priorisiert):**
+1) Persistente Evidence aktivieren: Workflows so anpassen, dass `scripts/ci-metrics.mjs` und `tools/loop-log.mjs` Outputs erzeugen und via `scripts/commit-if-changed.mjs` einchecken (Loop-Logs & ci-metrics.jsonl).【F:scripts/ci-metrics.mjs†L1-L42】【F:tools/loop-log.mjs†L1-L189】【F:scripts/commit-if-changed.mjs†L23-L41】
+2) Execution-Outputs versionieren: Prompt-Runs dokumentieren und relevante Dateien unter `artefacts/execution/` ablegen, um AT-002 abzuschließen.【067dd4†L1-L5】【F:tickets/AT-002.md†L26-L35】
+3) Hybrid-Trigger evidenzieren: Sicherstellen, dass `/codex`-Runs `artefacts/reports/codex_triggers.log` aktualisieren und Ticket-DoD (Screenshots/Logs) im Repo referenzieren.【F:.github/workflows/codex-run.yml†L19-L27】【F:tickets/AT-PATCH-01.md†L24-L26】


### PR DESCRIPTION
## Summary
- add the Deep Analysis Gap Report for M1 v1.1 covering governance and self-healing deliverables

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dd9079de1c832e837528a66ebd0834