### PR TITLE
chore(ci): persist metrics and loop logs

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -73,14 +73,15 @@ jobs:
       - name: Metrics (write)
         if: always()
         env:
-          RATE_PER_MIN: ${{ env.RATE_PER_MIN }}
+          RATE_PER_MIN: ${{ env.RATE_PER_MIN || 0.008 }}
         run: |
           END_TS=$(date +%s)
           DUR=$(( END_TS - ${START_TS:-END_TS} ))
           node scripts/ci-metrics.mjs auto-format ${{ job.status }} --duration $DUR --rate ${RATE_PER_MIN:-0}
-        continue-on-error: true
-
-      - name: Persist metrics (commit if changed)
+      - name: Loop Log (non-blocking)
+        if: always()
+        run: node tools/loop-log.mjs --ticket-from-branch --summary "$GITHUB_STEP_SUMMARY" || true
+      - name: Persist metrics/logs if changed
         if: always()
         run: node scripts/commit-if-changed.mjs
         continue-on-error: true

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -128,12 +128,10 @@ jobs:
           END_TS=$(date +%s)
           DUR=$(( END_TS - ${START_TS:-END_TS} ))
           node scripts/ci-metrics.mjs governance-summary ${{ job.status }} --duration $DUR --rate ${RATE_PER_MIN:-0}
-        continue-on-error: true
-
-      - name: Persist metrics (commit if changed)
-        if: always()
-        run: node scripts/commit-if-changed.mjs
-        continue-on-error: true
       - name: Loop Log (non-blocking)
         if: always()
         run: node tools/loop-log.mjs --ticket-from-branch --summary "$GITHUB_STEP_SUMMARY" || true
+      - name: Persist metrics/logs if changed
+        if: always()
+        run: node scripts/commit-if-changed.mjs
+        continue-on-error: true

--- a/scripts/commit-if-changed.mjs
+++ b/scripts/commit-if-changed.mjs
@@ -1,43 +1,92 @@
 #!/usr/bin/env node
 // Commit and push metrics/log updates for same-repo pull requests.
 
+import fs from "node:fs";
 import { execSync } from "node:child_process";
 
-function sh(cmd) {
-  return execSync(cmd, { stdio: "pipe" }).toString().trim();
+const TRACKED_PATHS = [
+  "artefacts/reports/ci-metrics.jsonl",
+  "artefacts/loop_logs",
+];
+
+const run = (cmd) => execSync(cmd, { stdio: "pipe" }).toString().trim();
+
+function isSameRepoPullRequest(repo) {
+  const headRef = process.env.GITHUB_HEAD_REF || "";
+  if (!headRef || !repo) {
+    return false;
+  }
+
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    try {
+      const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+      const prRepo = payload?.pull_request?.head?.repo?.full_name;
+      return prRepo ? prRepo === repo : false;
+    } catch {
+      // ignore parse errors and fall through to env heuristic
+    }
+  }
+
+  const owner = process.env.GITHUB_REPOSITORY_OWNER || "";
+  const repoName = repo.split("/")[1] || "";
+  const derived = owner && repoName ? `${owner}/${repoName}` : "";
+  return Boolean(derived && derived === repo);
+}
+
+function stageTrackedPaths() {
+  const addArgs = TRACKED_PATHS.join(" ");
+  try {
+    run(`git add -- ${addArgs}`);
+  } catch {
+    // ignore staging errors, files may not exist yet
+  }
+}
+
+function getStagedTrackedFiles() {
+  const stagedOutput = run("git diff --cached --name-only");
+  if (!stagedOutput) {
+    return [];
+  }
+  return stagedOutput
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function allPathsAllowed(staged) {
+  return staged.every((file) => {
+    if (file === TRACKED_PATHS[0]) {
+      return true;
+    }
+    return file.startsWith(`${TRACKED_PATHS[1]}/`);
+  });
 }
 
 try {
   const repo = process.env.GITHUB_REPOSITORY || "";
-  const owner = process.env.GITHUB_REPOSITORY_OWNER || "";
-  const repoName = repo.split("/")[1] || "";
-  const prRepo = owner && repoName ? `${owner}/${repoName}` : "";
-  const headRef = process.env.GITHUB_HEAD_REF || "";
-  const isSameRepo = Boolean(headRef && prRepo && prRepo === repo);
-
-  if (!isSameRepo) {
+  if (!isSameRepoPullRequest(repo)) {
     console.log("skip commit: fork or missing headRef");
     process.exit(0);
   }
 
-  try {
-    sh(
-      "git add artefacts/reports/ci-metrics.jsonl artefacts/loop_logs || true",
-    );
-  } catch {
-    // ignore staging errors
-  }
-
-  const status = sh("git status --porcelain");
-  if (!status) {
-    console.log("no changes to commit");
+  stageTrackedPaths();
+  const staged = getStagedTrackedFiles();
+  if (staged.length === 0) {
+    console.log("no changes");
     process.exit(0);
   }
 
-  sh('git config user.name "github-actions[bot]"');
-  sh('git config user.email "github-actions[bot]@users.noreply.github.com"');
-  sh('git commit -m "chore(ci): persist metrics & loop-log [skip ci]"');
-  sh(`git push origin HEAD:${headRef}`);
+  if (!allPathsAllowed(staged)) {
+    console.log("skip commit: staged files outside artefacts scope");
+    process.exit(0);
+  }
+
+  run('git config user.name "github-actions[bot]"');
+  run('git config user.email "github-actions[bot]@users.noreply.github.com"');
+  run('git commit -m "chore(ci): persist metrics & loop-log [skip ci]"');
+  const headRef = process.env.GITHUB_HEAD_REF || "";
+  run(`git push origin HEAD:${headRef}`);
   console.log("persisted metrics/logs");
 } catch (error) {
   console.log("non-blocking:", error?.message || error);

--- a/tools/loop-log.mjs
+++ b/tools/loop-log.mjs
@@ -178,12 +178,11 @@ function main() {
       summary: args.summary,
     });
     const filePath = writeLogFile({ ticket, runId, body });
-    console.log("loop-log written:", filePath);
-    process.exit(0);
+    console.log("loop-log:", filePath);
   } catch (error) {
-    console.error("loop-log failed:", error.message);
-    process.exit(0);
+    console.log("non-blocking:", error?.message || error);
   }
+  process.exit(0);
 }
 
 main();


### PR DESCRIPTION
## Summary
- harden the metrics persistence script to only push artefact changes for same-repo pull requests
- add metrics/loop log steps to auto-format and governance workflows with default cost estimation
- make the loop-log helper script resilient and consistently non-blocking

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd93eb2250832ea1f831bf065a25cd