### PR TITLE
Log codex triggers and guard same-repo commits

### DIFF
--- a/.github/workflows/codex-run.yml
+++ b/.github/workflows/codex-run.yml
@@ -19,12 +19,18 @@ jobs:
       - name: Write codex trigger marker
         run: |
           mkdir -p artefacts/reports
-          echo "codex trigger by @${{ github.actor }} at $GITHUB_RUN_ID" >> artefacts/reports/codex_triggers.log
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add artefacts/reports/codex_triggers.log
-          git commit -m "chore(codex): trigger marker"
-          git push
+          echo "$(date -Is) codex trigger by @${{ github.actor }} in PR #${{ github.event.issue.number }}" >> artefacts/reports/codex_triggers.log
+      - name: Commit marker (same-repo only)
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name || '' }}" = "${{ github.repository }}" ]; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add artefacts/reports/codex_triggers.log
+            git commit -m "chore(codex): trigger log [skip ci]" || echo "nothing to commit"
+            git push
+          else
+            echo "skip commit (fork or missing head.ref)"
+          fi
       - name: Acknowledge
         uses: actions/github-script@v7
         with:

--- a/artefacts/loop_logs/_unknown_18175378108.md
+++ b/artefacts/loop_logs/_unknown_18175378108.md
@@ -6,4 +6,5 @@
 - workflow: auto-format
 
 ## Summary
-/home/runner/work/_temp/_runner_file_commands/step_summary_1e9e6cfa-649c-4bb1-b137-bafb1d4c1737
+
+/home/runner/work/\_temp/\_runner_file_commands/step_summary_1e9e6cfa-649c-4bb1-b137-bafb1d4c1737


### PR DESCRIPTION
## Summary
- log codex trigger events with timestamp, actor, and PR number
- only commit the codex trigger log when the comment comes from a same-repo pull request

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd95843f38832eb53ad9543e59acfd