### PR TITLE
AT-PATCH-12: Guard Prettier auto-fix in governance workflow

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -20,6 +20,7 @@ permissions:
 
 env:
   SHADOW_MODE: true
+  MAX_AUTOFIX_COMMITS: 1
 
 jobs:
   run-checks:
@@ -41,8 +42,20 @@ jobs:
         continue-on-error: true
         run: npx --yes prettier --check .
 
+      - name: Count previous bot commits
+        id: count
+        shell: bash
+        run: |
+          COUNT=$( {
+            git log --pretty='%an\t%s' 2>/dev/null || true
+          } | awk -F'\t' '$1 == "github-actions[bot]" && $2 == "chore(prettier): auto-format via CI" {c++} END {print c+0}')
+          echo "n=${COUNT:-0}" >> "$GITHUB_OUTPUT"
+
       - name: Prettier (write & commit)
-        if: steps.prettier.outcome == 'failure'
+        if: |
+          steps.prettier.outcome == 'failure' &&
+          steps.count.outputs.n < env.MAX_AUTOFIX_COMMITS &&
+          github.event.pull_request.head.repo.full_name == github.repository
         run: |
           npx --yes prettier --write .
           git config user.name  "github-actions[bot]"

--- a/artefacts/loop_logs/AT-PATCH-12_18204339215.md
+++ b/artefacts/loop_logs/AT-PATCH-12_18204339215.md
@@ -6,4 +6,5 @@
 - workflow: auto-format
 
 ## Summary
-/home/runner/work/_temp/_runner_file_commands/step_summary_47ab3d41-b1ef-40bc-ab2d-a373e27dae82
+
+/home/runner/work/\_temp/\_runner_file_commands/step_summary_47ab3d41-b1ef-40bc-ab2d-a373e27dae82

--- a/artefacts/loop_logs/AT-PATCH-12_18204676309.md
+++ b/artefacts/loop_logs/AT-PATCH-12_18204676309.md
@@ -1,0 +1,9 @@
+# Loop Log
+
+- ts: 2025-10-02T20:21:57.205Z
+- run_id: 18204676309
+- ticket: AT-PATCH-12
+- workflow: auto-format
+
+## Summary
+/home/runner/work/_temp/_runner_file_commands/step_summary_23543367-1ed2-41bb-a553-1b4694cd805e

--- a/artefacts/reports/ci-metrics.jsonl
+++ b/artefacts/reports/ci-metrics.jsonl
@@ -4,3 +4,4 @@
 {"ts":"2025-10-01T21:30:52.206Z","workflow":"auto-format","run_id":"18176226991","job":"auto-format","result":"success","duration_s":12,"duration_min":0.2,"est_cost_usd":0.0016}
 {"ts":"2025-10-02T19:48:45.957Z","workflow":"auto-format","run_id":"18203924954","job":"auto-format","result":"success","duration_s":6,"duration_min":0.1,"est_cost_usd":0.0008}
 {"ts":"2025-10-02T20:07:56.645Z","workflow":"auto-format","run_id":"18204339215","job":"auto-format","result":"success","duration_s":9,"duration_min":0.15,"est_cost_usd":0.0012}
+{"ts":"2025-10-02T20:21:57.157Z","workflow":"auto-format","run_id":"18204676309","job":"auto-format","result":"success","duration_s":15,"duration_min":0.25,"est_cost_usd":0.002}


### PR DESCRIPTION
## What
- add a MAX_AUTOFIX_COMMITS guardrail and count existing bot commits before auto-fixing
- gate the Prettier write-and-commit step on failures, same-repo PRs, and the commit-count check
- retain the follow-up Prettier re-check so the remaining governance jobs always execute

## Why
- prevent Prettier errors from blocking governance runs while avoiding endless auto-fix loops

## Guardrail
- limit CI-triggered Prettier commits to at most `MAX_AUTOFIX_COMMITS=1` per branch via the commit counter

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68deddc32e50832ebed18e5781adff90