### PR TITLE
docs: add M1 v1.4 deep analysis gap report

### DIFF
--- a/artefacts/loop_logs/AT-PATCH-12_18204676309.md
+++ b/artefacts/loop_logs/AT-PATCH-12_18204676309.md
@@ -6,4 +6,5 @@
 - workflow: auto-format
 
 ## Summary
-/home/runner/work/_temp/_runner_file_commands/step_summary_23543367-1ed2-41bb-a553-1b4694cd805e
+
+/home/runner/work/\_temp/\_runner_file_commands/step_summary_23543367-1ed2-41bb-a553-1b4694cd805e

--- a/artefacts/loop_logs/_unknown_18204935421.md
+++ b/artefacts/loop_logs/_unknown_18204935421.md
@@ -1,0 +1,9 @@
+# Loop Log
+
+- ts: 2025-10-02T20:33:21.719Z
+- run_id: 18204935421
+- ticket: unknown
+- workflow: auto-format
+
+## Summary
+/home/runner/work/_temp/_runner_file_commands/step_summary_b895eb27-bce5-42d4-a424-e811516696c0

--- a/artefacts/reports/ci-metrics.jsonl
+++ b/artefacts/reports/ci-metrics.jsonl
@@ -5,3 +5,4 @@
 {"ts":"2025-10-02T19:48:45.957Z","workflow":"auto-format","run_id":"18203924954","job":"auto-format","result":"success","duration_s":6,"duration_min":0.1,"est_cost_usd":0.0008}
 {"ts":"2025-10-02T20:07:56.645Z","workflow":"auto-format","run_id":"18204339215","job":"auto-format","result":"success","duration_s":9,"duration_min":0.15,"est_cost_usd":0.0012}
 {"ts":"2025-10-02T20:21:57.157Z","workflow":"auto-format","run_id":"18204676309","job":"auto-format","result":"success","duration_s":15,"duration_min":0.25,"est_cost_usd":0.002}
+{"ts":"2025-10-02T20:33:21.675Z","workflow":"auto-format","run_id":"18204935421","job":"auto-format","result":"success","duration_s":13,"duration_min":0.22,"est_cost_usd":0.0017}

--- a/artefacts/reports/deep_analysis_gap_m1_v1.4.md
+++ b/artefacts/reports/deep_analysis_gap_m1_v1.4.md
@@ -1,0 +1,27 @@
+# Deep Analysis Gap Report – M1 v1.4
+
+## 1. Übersicht
+Nach Merge von AT-PATCH-12 liegen die Self-Healing-Bausteine aus M1 sichtbar im Repo: Health-Check & Iteration-Log aus AT-001, Governance-/Validator-Skripte samt Execution-Evidence aus AT-002, Friction-Bundle-Artefakte aus AT-PATCH-01 sowie der neue Prettier-Auto-Fix-Guardrail in `governance.yml`. Gleichzeitig fehlen noch belastbare Codex-/Governance-Evidenzen, sodass „READY" noch nicht erreicht ist.
+
+## 2. Gap-Tabelle
+| Ticket | Soll-Deliverables | Ist im Repo | Status | Kommentar |
+| --- | --- | --- | --- | --- |
+| AT-001 | Health-Script, npm-Skript, CI-Step, Iteration-Log | `tools/health-check.mjs`, `npm run health`, `ci.yml`-Step und Iterations-Eintrag vorhanden. | OK | Script & CI-Step liefern gewünschten Health-Check, Iteration-Log dokumentiert Umsetzung. |
+| AT-002 | Governance-/Validator-Skripte, UTF-8 Check, Loop-Log, Execution-Evidence | Validator/UTF-8-Skripte, Loop-Log-Tool und Execution-Beispiel im Repo. | Drift | Skripte vorhanden, aber keine aktuellen Governance-Metriken/Loop-Summaries → Evidence-Qualität verbesserungsfähig. |
+| AT-PATCH-01 | PR-/Issue-Templates, Editor Defaults, Codex-Workflow, Guardrail | Alle Operator-Artefakte vorhanden, Codex-Workflow schreibt Marker. | Drift | `codex_triggers.log` fehlt → keine nachweisbare Trigger-Evidence trotz Workflow. |
+| AT-PATCH-12 | Prettier Auto-Fix (check → write/commit → re-check) + Guardrail & Logs | Governance-Workflow enthält Auto-Fix-Sequenz mit Same-Repo-Guard & Loop-Logging. | Drift | Loop-Logs zeigen nur Pfad-Verweise, keine nachvollziehbare Zusammenfassung; Governance-Metrics fehlen → Auto-Fix-Erfolg schwer belegbar. |
+
+## 3. Globale Gaps
+- Keine `artefacts/reports/codex_triggers.log` Datei → Codex-Trigger bleiben unprotokolliert (AT-PATCH-01 Evidence-Lücke).
+- `artefacts/reports/ci-metrics.jsonl` enthält nur `auto-format`-Runs; Governance-Laufzeiten/Kosten fehlen (AT-002/AT-PATCH-12 KPIs nicht messbar).
+- Loop-Logs für AT-PATCH-12 verlinken nur auf Runner-Pfade statt Zusammenfassungen → Self-Healing-Nachweise unlesbar.
+
+## 4. CI-Kosten
+- Einträge: 7, Gesamt-Dauer: 1m 8s, Kosten: $0.0090
+
+## 5. Empfehlung
+**Entscheidung:** M1: NOT READY
+**Nächste Schritte (max. 3):**
+1) Governance-Run erzwingen und sicherstellen, dass `ci-metrics.jsonl` Governance-/UTF-8-/Validator-Jobs mitprotokolliert.
+2) `codex-run` Workflow testen (Kommentar `/codex`) und das resultierende `artefacts/reports/codex_triggers.log` einchecken.
+3) Loop-Log-Summary-Output verbessern (z. B. Step-Summary-Inhalt extrahieren) und aktuelle Governance-Auto-Fix-Ergebnisse dokumentieren.

--- a/artefacts/reports/deep_analysis_gap_m1_v1.4.md
+++ b/artefacts/reports/deep_analysis_gap_m1_v1.4.md
@@ -1,27 +1,33 @@
 # Deep Analysis Gap Report – M1 v1.4
 
 ## 1. Übersicht
+
 Nach Merge von AT-PATCH-12 liegen die Self-Healing-Bausteine aus M1 sichtbar im Repo: Health-Check & Iteration-Log aus AT-001, Governance-/Validator-Skripte samt Execution-Evidence aus AT-002, Friction-Bundle-Artefakte aus AT-PATCH-01 sowie der neue Prettier-Auto-Fix-Guardrail in `governance.yml`. Gleichzeitig fehlen noch belastbare Codex-/Governance-Evidenzen, sodass „READY" noch nicht erreicht ist.
 
 ## 2. Gap-Tabelle
-| Ticket | Soll-Deliverables | Ist im Repo | Status | Kommentar |
-| --- | --- | --- | --- | --- |
-| AT-001 | Health-Script, npm-Skript, CI-Step, Iteration-Log | `tools/health-check.mjs`, `npm run health`, `ci.yml`-Step und Iterations-Eintrag vorhanden. | OK | Script & CI-Step liefern gewünschten Health-Check, Iteration-Log dokumentiert Umsetzung. |
-| AT-002 | Governance-/Validator-Skripte, UTF-8 Check, Loop-Log, Execution-Evidence | Validator/UTF-8-Skripte, Loop-Log-Tool und Execution-Beispiel im Repo. | Drift | Skripte vorhanden, aber keine aktuellen Governance-Metriken/Loop-Summaries → Evidence-Qualität verbesserungsfähig. |
-| AT-PATCH-01 | PR-/Issue-Templates, Editor Defaults, Codex-Workflow, Guardrail | Alle Operator-Artefakte vorhanden, Codex-Workflow schreibt Marker. | Drift | `codex_triggers.log` fehlt → keine nachweisbare Trigger-Evidence trotz Workflow. |
-| AT-PATCH-12 | Prettier Auto-Fix (check → write/commit → re-check) + Guardrail & Logs | Governance-Workflow enthält Auto-Fix-Sequenz mit Same-Repo-Guard & Loop-Logging. | Drift | Loop-Logs zeigen nur Pfad-Verweise, keine nachvollziehbare Zusammenfassung; Governance-Metrics fehlen → Auto-Fix-Erfolg schwer belegbar. |
+
+| Ticket      | Soll-Deliverables                                                        | Ist im Repo                                                                                 | Status | Kommentar                                                                                                                                |
+| ----------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| AT-001      | Health-Script, npm-Skript, CI-Step, Iteration-Log                        | `tools/health-check.mjs`, `npm run health`, `ci.yml`-Step und Iterations-Eintrag vorhanden. | OK     | Script & CI-Step liefern gewünschten Health-Check, Iteration-Log dokumentiert Umsetzung.                                                 |
+| AT-002      | Governance-/Validator-Skripte, UTF-8 Check, Loop-Log, Execution-Evidence | Validator/UTF-8-Skripte, Loop-Log-Tool und Execution-Beispiel im Repo.                      | Drift  | Skripte vorhanden, aber keine aktuellen Governance-Metriken/Loop-Summaries → Evidence-Qualität verbesserungsfähig.                       |
+| AT-PATCH-01 | PR-/Issue-Templates, Editor Defaults, Codex-Workflow, Guardrail          | Alle Operator-Artefakte vorhanden, Codex-Workflow schreibt Marker.                          | Drift  | `codex_triggers.log` fehlt → keine nachweisbare Trigger-Evidence trotz Workflow.                                                         |
+| AT-PATCH-12 | Prettier Auto-Fix (check → write/commit → re-check) + Guardrail & Logs   | Governance-Workflow enthält Auto-Fix-Sequenz mit Same-Repo-Guard & Loop-Logging.            | Drift  | Loop-Logs zeigen nur Pfad-Verweise, keine nachvollziehbare Zusammenfassung; Governance-Metrics fehlen → Auto-Fix-Erfolg schwer belegbar. |
 
 ## 3. Globale Gaps
+
 - Keine `artefacts/reports/codex_triggers.log` Datei → Codex-Trigger bleiben unprotokolliert (AT-PATCH-01 Evidence-Lücke).
 - `artefacts/reports/ci-metrics.jsonl` enthält nur `auto-format`-Runs; Governance-Laufzeiten/Kosten fehlen (AT-002/AT-PATCH-12 KPIs nicht messbar).
 - Loop-Logs für AT-PATCH-12 verlinken nur auf Runner-Pfade statt Zusammenfassungen → Self-Healing-Nachweise unlesbar.
 
 ## 4. CI-Kosten
+
 - Einträge: 7, Gesamt-Dauer: 1m 8s, Kosten: $0.0090
 
 ## 5. Empfehlung
+
 **Entscheidung:** M1: NOT READY
 **Nächste Schritte (max. 3):**
-1) Governance-Run erzwingen und sicherstellen, dass `ci-metrics.jsonl` Governance-/UTF-8-/Validator-Jobs mitprotokolliert.
-2) `codex-run` Workflow testen (Kommentar `/codex`) und das resultierende `artefacts/reports/codex_triggers.log` einchecken.
-3) Loop-Log-Summary-Output verbessern (z. B. Step-Summary-Inhalt extrahieren) und aktuelle Governance-Auto-Fix-Ergebnisse dokumentieren.
+
+1. Governance-Run erzwingen und sicherstellen, dass `ci-metrics.jsonl` Governance-/UTF-8-/Validator-Jobs mitprotokolliert.
+2. `codex-run` Workflow testen (Kommentar `/codex`) und das resultierende `artefacts/reports/codex_triggers.log` einchecken.
+3. Loop-Log-Summary-Output verbessern (z. B. Step-Summary-Inhalt extrahieren) und aktuelle Governance-Auto-Fix-Ergebnisse dokumentieren.


### PR DESCRIPTION
## Summary
- add the v1.4 deep analysis report for milestone 1 after AT-PATCH-12
- capture remaining evidence gaps in governance metrics, codex triggers, and loop logs

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dee03ebc88832eaad3c52dc6a189fd