### PR TITLE
chore: pause governance and automation workflows

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,16 +1,7 @@
 name: auto-format
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - '**/*.md'
-      - '**/*.json'
-      - '**/*.yml'
-      - '**/*.yaml'
-      - 'scripts/**'
-      - '.prettierignore'
-      - '.editorconfig'
+  workflow_dispatch: {}
 
 concurrency:
   group: auto-format-${{ github.ref }}

--- a/.github/workflows/codex-run.yml
+++ b/.github/workflows/codex-run.yml
@@ -1,8 +1,7 @@
 name: codex-run
 
 on:
-  issue_comment:
-    types: [created]
+  workflow_dispatch: {}
 
 permissions:
   contents: write

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,12 +1,7 @@
 name: governance
 
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'tickets/**'
-      - 'scripts/**'
-      - '.github/workflows/**'
+  workflow_dispatch: {}
 
 concurrency:
   group: governance-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- switch governance, auto-format, and codex-run workflows to manual dispatch only
- retain workflow definitions for future reactivation while preventing automatic triggers

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68df016476b4832e9981bb3eaf36f100